### PR TITLE
Fix MariaDB not working

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 			<plugin>
                 <groupId>net.md-5</groupId>
                 <artifactId>specialsource-maven-plugin</artifactId>
-                <version>1.2.4</version>
+                <version>2.0.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -37,9 +37,9 @@
                         </goals>
                         <id>remap-obf</id>
                         <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.20.1-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+                            <srgIn>org.spigotmc:minecraft-server:1.20.6-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
                             <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.20.1-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
+                            <remappedDependencies>org.spigotmc:spigot:1.20.6-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
                             <remappedArtifactAttached>true</remappedArtifactAttached>
                             <remappedClassifierName>remapped-obf</remappedClassifierName>
                         </configuration>
@@ -52,8 +52,8 @@
                         <id>remap-spigot</id>
                         <configuration>
                             <inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.20.1-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.20.1-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
+                            <srgIn>org.spigotmc:minecraft-server:1.20.6-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
+                            <remappedDependencies>org.spigotmc:spigot:1.20.6-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
                         </configuration>
                     </execution>
                 </executions>
@@ -64,15 +64,15 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>                
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.6.0</version>
 
                 <configuration>
                     <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.20-R0.1-SNAPSHOT</version>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
             <classifier>remapped-mojang</classifier>
             <scope>provided</scope>
         </dependency>
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>1.18.32</version>
         </dependency>
 
         <dependency>
@@ -177,7 +177,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>2.4.1</version>
+            <version>5.1.0</version>
         </dependency>
         <dependency>
             <groupId>co.aikar</groupId>
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.3</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,12 @@
             <version>1.7.0</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>3.1.2</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/me/makkuusen/timing/system/ApiUtilities.java
+++ b/src/main/java/me/makkuusen/timing/system/ApiUtilities.java
@@ -12,7 +12,7 @@ import com.sk89q.worldedit.regions.Polygonal2DRegion;
 import com.sk89q.worldedit.regions.Region;
 import me.makkuusen.timing.system.api.TimingSystemAPI;
 import me.makkuusen.timing.system.api.events.BoatSpawnEvent;
-import me.makkuusen.timing.system.boat.v1_20_R1.BoatSpawner;
+import me.makkuusen.timing.system.boat.v1_20_R4.BoatSpawner;
 import me.makkuusen.timing.system.boatutils.BoatUtilsManager;
 import me.makkuusen.timing.system.boatutils.BoatUtilsMode;
 import me.makkuusen.timing.system.database.TSDatabase;
@@ -414,14 +414,14 @@ public class ApiUtilities {
         Boat boat;
         
         if (isChestBoat) {
-        	if (isServerVersion1_20_1()) { // TODO add option to turn off boat lag prevention
+        	if (isServerVersion1_20_6()) { // TODO add option to turn off boat lag prevention
         		boat = BoatSpawner.spawnChestBoat(location);        		
         	} else {
         		 boat = (Boat) location.getWorld().spawnEntity(location, EntityType.CHEST_BOAT);
         		 
         	}           
         } else {
-        	if (isServerVersion1_20_1()) { // TODO add option to turn off boat lag prevention
+        	if (isServerVersion1_20_6()) { // TODO add option to turn off boat lag prevention
         		boat = BoatSpawner.spawnBoat(location);        		
         	} else {
         		boat = (Boat) location.getWorld().spawnEntity(location, EntityType.BOAT);        		
@@ -436,8 +436,8 @@ public class ApiUtilities {
         return boat;
     }
     
-    private static boolean isServerVersion1_20_1() {
-    	return Bukkit.getVersion().contains("1.20.1");
+    private static boolean isServerVersion1_20_6() {
+    	return Bukkit.getVersion().contains("1.20.6");
     }
 
     public static Optional<Region> getSelection(Player player) {

--- a/src/main/java/me/makkuusen/timing/system/Tasks.java
+++ b/src/main/java/me/makkuusen/timing/system/Tasks.java
@@ -47,7 +47,7 @@ public class Tasks {
                 track.getTrackLocations().getLocations(TrackLocation.Type.GRID).forEach(location -> setParticles(player, location.getLocation(), Particle.WAX_OFF));
                 track.getTrackLocations().getLocations(TrackLocation.Type.QUALYGRID).forEach(location -> setParticles(player, location.getLocation(), Particle.WAX_ON));
                 track.getTrackLocations().getLocations(TrackLocation.Type.FINISH_TP).forEach(location -> setParticles(player, location.getLocation(), Particle.HEART));
-                track.getTrackLocations().getLocations(TrackLocation.Type.FINISH_TP_ALL).forEach(location -> setParticles(player, location.getLocation(), Particle.VILLAGER_ANGRY));
+                track.getTrackLocations().getLocations(TrackLocation.Type.FINISH_TP_ALL).forEach(location -> setParticles(player, location.getLocation(), Particle.ANGRY_VILLAGER));
             }
         }, 0, 10);
     }
@@ -215,13 +215,13 @@ public class Tasks {
         } else if (region.getRegionType().equals(TrackRegion.RegionType.RESET)) {
             particle = Particle.WAX_ON;
         } else if (region.getRegionType().equals(TrackRegion.RegionType.START)) {
-            particle = Particle.VILLAGER_HAPPY;
+            particle = Particle.HAPPY_VILLAGER;
         } else if (region.getRegionType().equals(TrackRegion.RegionType.END)) {
-            particle = Particle.VILLAGER_ANGRY;
+            particle = Particle.ANGRY_VILLAGER;
         } else if (region.getRegionType().equals(TrackRegion.RegionType.PIT)) {
             particle = Particle.HEART;
         } else if (region.getRegionType().equals(TrackRegion.RegionType.INPIT)) {
-            particle = Particle.SPELL_WITCH;
+            particle = Particle.WITCH;
         } else {
             particle = Particle.WAX_OFF;
         }

--- a/src/main/java/me/makkuusen/timing/system/boat/v1_20_R4/BoatSpawner.java
+++ b/src/main/java/me/makkuusen/timing/system/boat/v1_20_R4/BoatSpawner.java
@@ -1,11 +1,11 @@
-package me.makkuusen.timing.system.boat.v1_20_R1;
+package me.makkuusen.timing.system.boat.v1_20_R4;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_20_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_20_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_20_R1.entity.CraftBoat;
-import org.bukkit.craftbukkit.v1_20_R1.entity.CraftChestBoat;
+import org.bukkit.craftbukkit.v1_20_R4.CraftServer;
+import org.bukkit.craftbukkit.v1_20_R4.CraftWorld;
+import org.bukkit.craftbukkit.v1_20_R4.entity.CraftBoat;
+import org.bukkit.craftbukkit.v1_20_R4.entity.CraftChestBoat;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 
 import net.minecraft.server.level.ServerLevel;

--- a/src/main/java/me/makkuusen/timing/system/boat/v1_20_R4/CollisionlessBoat.java
+++ b/src/main/java/me/makkuusen/timing/system/boat/v1_20_R4/CollisionlessBoat.java
@@ -1,4 +1,4 @@
-package me.makkuusen.timing.system.boat.v1_20_R1;
+package me.makkuusen.timing.system.boat.v1_20_R4;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.vehicle.Boat;

--- a/src/main/java/me/makkuusen/timing/system/boat/v1_20_R4/CollisionlessChestBoat.java
+++ b/src/main/java/me/makkuusen/timing/system/boat/v1_20_R4/CollisionlessChestBoat.java
@@ -1,4 +1,4 @@
-package me.makkuusen.timing.system.boat.v1_20_R1;
+package me.makkuusen.timing.system.boat.v1_20_R4;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;

--- a/src/main/java/me/makkuusen/timing/system/database/MariaDBDatabase.java
+++ b/src/main/java/me/makkuusen/timing/system/database/MariaDBDatabase.java
@@ -7,6 +7,8 @@ import co.aikar.idb.PooledDatabaseOptions;
 import me.makkuusen.timing.system.TimingSystem;
 import me.makkuusen.timing.system.TimingSystemConfiguration;
 
+import java.util.HashMap;
+
 public class MariaDBDatabase extends MySQLDatabase {
     @Override
     public boolean initialize() {
@@ -14,7 +16,11 @@ public class MariaDBDatabase extends MySQLDatabase {
         String hostAndPort = config.getSqlHost() + ":" + config.getSqlPort();
 
         PooledDatabaseOptions options = BukkitDB.getRecommendedOptions(TimingSystem.getPlugin(), config.getSqlUsername(), config.getSqlPassword(), config.getSqlDatabase(), hostAndPort);
-        options.getOptions().setDsn("mysql://" + hostAndPort + "/" + config.getSqlDatabase());
+
+        //Fix invalid MariaDB Options
+        options.getOptions().setDsn("mariadb://" + hostAndPort + "/" + config.getSqlDatabase());
+        //End Fix
+
         options.setMinIdleConnections(5);
         options.setMaxConnections(5);
         co.aikar.idb.Database db = new HikariPooledDatabase(options);

--- a/src/main/java/me/makkuusen/timing/system/database/MariaDBDatabase.java
+++ b/src/main/java/me/makkuusen/timing/system/database/MariaDBDatabase.java
@@ -7,8 +7,6 @@ import co.aikar.idb.PooledDatabaseOptions;
 import me.makkuusen.timing.system.TimingSystem;
 import me.makkuusen.timing.system.TimingSystemConfiguration;
 
-import java.util.HashMap;
-
 public class MariaDBDatabase extends MySQLDatabase {
     @Override
     public boolean initialize() {
@@ -16,7 +14,7 @@ public class MariaDBDatabase extends MySQLDatabase {
         String hostAndPort = config.getSqlHost() + ":" + config.getSqlPort();
 
         PooledDatabaseOptions options = BukkitDB.getRecommendedOptions(TimingSystem.getPlugin(), config.getSqlUsername(), config.getSqlPassword(), config.getSqlDatabase(), hostAndPort);
-        options.getOptions().setDsn("mariadb://" + hostAndPort + "/" + config.getSqlDatabase());
+        options.getOptions().setDsn("mysql://" + hostAndPort + "/" + config.getSqlDatabase());
         options.setMinIdleConnections(5);
         options.setMaxConnections(5);
         co.aikar.idb.Database db = new HikariPooledDatabase(options);

--- a/src/main/java/me/makkuusen/timing/system/database/MariaDBDatabase.java
+++ b/src/main/java/me/makkuusen/timing/system/database/MariaDBDatabase.java
@@ -17,9 +17,6 @@ public class MariaDBDatabase extends MySQLDatabase {
 
         PooledDatabaseOptions options = BukkitDB.getRecommendedOptions(TimingSystem.getPlugin(), config.getSqlUsername(), config.getSqlPassword(), config.getSqlDatabase(), hostAndPort);
         options.getOptions().setDsn("mariadb://" + hostAndPort + "/" + config.getSqlDatabase());
-        options.setDataSourceProperties(new HashMap<>() {{
-            put("useSSL", false);
-        }});
         options.setMinIdleConnections(5);
         options.setMaxConnections(5);
         co.aikar.idb.Database db = new HikariPooledDatabase(options);

--- a/src/main/java/me/makkuusen/timing/system/gui/TrackFilter.java
+++ b/src/main/java/me/makkuusen/timing/system/gui/TrackFilter.java
@@ -57,7 +57,7 @@ public class TrackFilter {
     public ItemStack getItem(TPlayer tPlayer){
         var item = new ItemBuilder(Material.HOPPER).setName(Text.get(tPlayer, Gui.FILTER_BY)).build();
         ItemMeta im = getItemMeta(tPlayer, item);
-        im.addEnchant(Enchantment.LUCK, 1, true);
+        im.addEnchant(Enchantment.LUCK_OF_THE_SEA, 1, true);
         im.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         im.addItemFlags(ItemFlag.HIDE_ARMOR_TRIM);
         im.addItemFlags(ItemFlag.HIDE_DYE);


### PR DESCRIPTION
Fixes the below error when using MariaDB:

Removes "useSsl" as it's deprecated and "sslMode" is disabled by default.
https://mariadb.com/kb/en/about-mariadb-connector-j/#tls-parameters

```
[20:06:34] [Server thread/ERROR]: Error occurred while enabling TimingSystem v2.2-SNAPSHOT (Is it up to date?)
java.lang.RuntimeException: java.beans.IntrospectionException: Method not found: setUseSSL
	at com.zaxxer.hikari.util.PropertyElf.setProperty(PropertyElf.java:141) ~[TimingSystem-2.2-SNAPSHOT+33b65e3.jar:?]
	at com.zaxxer.hikari.util.PropertyElf.setTargetFromProperties(PropertyElf.java:64) ~[TimingSystem-2.2-SNAPSHOT+33b65e3.jar:?]
	at com.zaxxer.hikari.pool.PoolElf.initializeDataSource(PoolElf.java:154) ~[TimingSystem-2.2-SNAPSHOT+33b65e3.jar:?]
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:113) ~[TimingSystem-2.2-SNAPSHOT+33b65e3.jar:?]
	at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:73) ~[TimingSystem-2.2-SNAPSHOT+33b65e3.jar:?]
	at me.makkuusen.timing.system.idb.HikariPooledDatabase.<init>(HikariPooledDatabase.java:56) ~[TimingSystem-2.2-SNAPSHOT+33b65e3.jar:?]
	at me.makkuusen.timing.system.database.MariaDBDatabase.initialize(MariaDBDatabase.java:25) ~[TimingSystem-2.2-SNAPSHOT+33b65e3.jar:?]
	at me.makkuusen.timing.system.TimingSystem.onEnable(TimingSystem.java:133) ~[TimingSystem-2.2-SNAPSHOT+33b65e3.jar:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:287) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:188) ~[paper-1.20.4.jar:git-Paper-464]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:104) ~[paper-1.20.4.jar:git-Paper-464]
	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:507) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_20_R3.CraftServer.enablePlugin(CraftServer.java:639) ~[paper-1.20.4.jar:git-Paper-464]
	at org.bukkit.craftbukkit.v1_20_R3.CraftServer.enablePlugins(CraftServer.java:550) ~[paper-1.20.4.jar:git-Paper-464]
	at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:671) ~[paper-1.20.4.jar:git-Paper-464]
	at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:431) ~[paper-1.20.4.jar:git-Paper-464]
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:309) ~[paper-1.20.4.jar:git-Paper-464]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1131) ~[paper-1.20.4.jar:git-Paper-464]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:319) ~[paper-1.20.4.jar:git-Paper-464]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
Caused by: java.beans.IntrospectionException: Method not found: setUseSSL
	at java.beans.PropertyDescriptor.<init>(PropertyDescriptor.java:114) ~[?:?]
	at com.zaxxer.hikari.util.PropertyElf.setProperty(PropertyElf.java:132) ~[TimingSystem-2.2-SNAPSHOT+33b65e3.jar:?]
	... 19 more
```