### PR TITLE
/heat set lapreset

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/TSListener.java
+++ b/src/main/java/me/makkuusen/timing/system/TSListener.java
@@ -590,6 +590,10 @@ public class TSListener implements Listener {
                     driver.resetQualyLap();
                     heat.updatePositions();
                     return;
+                } else if (driver.getState() == DriverState.LAPRESET) {
+                    driver.lapReset();
+                    heat.updatePositions();
+                    return;
                 } else if (driver.getCurrentLap() != null && driver.getCurrentLap().getLatestCheckpoint() != 0) {
                     if (!driver.getCurrentLap().hasPassedAllCheckpoints()) {
                         int checkpoint = driver.getCurrentLap().getLatestCheckpoint();

--- a/src/main/java/me/makkuusen/timing/system/Tasks.java
+++ b/src/main/java/me/makkuusen/timing/system/Tasks.java
@@ -135,7 +135,6 @@ public class Tasks {
     }
 
     private static void displayDriverTimer(Player player, Driver driver) {
-
         if (driver.getHeat().getRound() instanceof FinalRound) {
             if (!driver.isFinished()) {
                 player.sendActionBar(Text.get(player, ActionBar.RACE,"%laps%", String.valueOf(driver.getLaps().size()), "%totalLaps%", String.valueOf(driver.getHeat().getTotalLaps()), "%pos%", String.valueOf(driver.getPosition()), "%pits%", String.valueOf(driver.getPits()), "%totalPits%", String.valueOf(driver.getHeat().getTotalPits())));
@@ -146,7 +145,7 @@ public class Tasks {
     }
 
     private static void sendQualificationDriverActionBar(Player player, Driver driver) {
-        if (!driver.getLaps().isEmpty() && driver.getCurrentLap() != null && driver.getState() == DriverState.RUNNING) {
+        if (!driver.getLaps().isEmpty() && driver.getCurrentLap() != null && (driver.getState() == DriverState.RUNNING || driver.getState() == DriverState.RESET || driver.getState() == DriverState.LAPRESET)) {
             long lapTime = Duration.between(driver.getCurrentLap().getLapStart(), TimingSystem.currentTime).toMillis();
             long timeLeft = driver.getHeat().getTimeLimit() - Duration.between(driver.getStartTime(), TimingSystem.currentTime).toMillis();
             String delta = QualifyHeat.getBestLapCheckpointDelta(driver, driver.getCurrentLap().getLatestCheckpoint());

--- a/src/main/java/me/makkuusen/timing/system/commands/CommandBoat.java
+++ b/src/main/java/me/makkuusen/timing/system/commands/CommandBoat.java
@@ -11,7 +11,6 @@ import me.makkuusen.timing.system.theme.Text;
 import me.makkuusen.timing.system.theme.messages.Error;
 import me.makkuusen.timing.system.timetrial.TimeTrialController;
 import me.makkuusen.timing.system.track.Track;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;

--- a/src/main/java/me/makkuusen/timing/system/commands/CommandHeat.java
+++ b/src/main/java/me/makkuusen/timing/system/commands/CommandHeat.java
@@ -336,6 +336,14 @@ public class CommandHeat extends BaseCommand {
         Text.send(player, Success.SAVED);
     }
 
+    @Subcommand("set lapreset")
+    @CommandCompletion("@heat true|false")
+    @CommandPermission("%permissionheat_set_lapreset")
+    public static void onHeatSetLapReset(Player player, Heat heat, Boolean lapReset) {
+        heat.setLapReset(lapReset);
+        Text.send(player, Success.SAVED);
+    }
+
     @Subcommand("set driverposition")
     @CommandCompletion("@heat @players <[+/-]pos>")
     @CommandPermission("%permissionheat_set_driverposition")

--- a/src/main/java/me/makkuusen/timing/system/database/MySQLDatabase.java
+++ b/src/main/java/me/makkuusen/timing/system/database/MySQLDatabase.java
@@ -8,6 +8,7 @@ import me.makkuusen.timing.system.database.updates.Version2;
 import me.makkuusen.timing.system.database.updates.Version3;
 import me.makkuusen.timing.system.database.updates.Version4;
 import me.makkuusen.timing.system.database.updates.Version5;
+import me.makkuusen.timing.system.database.updates.Version6;
 import me.makkuusen.timing.system.event.Event;
 import me.makkuusen.timing.system.heat.Heat;
 import me.makkuusen.timing.system.heat.HeatState;
@@ -60,7 +61,7 @@ public class MySQLDatabase implements TSDatabase, EventDatabase, TrackDatabase, 
         try {
             var row = DB.getFirstRow("SELECT * FROM `ts_version` ORDER BY `date` DESC;");
 
-            int databaseVersion = 5;
+            int databaseVersion = 6;
             if (row == null) { // First startup
                 DB.executeInsert("INSERT INTO `ts_version` (`version`, `date`) VALUES('" + databaseVersion + "', " + ApiUtilities.getTimestamp() + ");");
                 return true;
@@ -116,6 +117,9 @@ public class MySQLDatabase implements TSDatabase, EventDatabase, TrackDatabase, 
         }
         if (previousVersion <5) {
             Version5.updateMySQL();
+        }
+        if (previousVersion < 6) {
+            Version6.updateMySQL();
         }
     }
 
@@ -423,7 +427,7 @@ public class MySQLDatabase implements TSDatabase, EventDatabase, TrackDatabase, 
     @Override
     public Heat createHeat(Round round, int heatIndex) {
         try {
-            var heatId = DB.executeInsert("INSERT INTO `ts_heats`(`roundId`, `heatNumber`, `state`, `startTime`, `endTime`, `fastestLapUUID`, `totalLaps`, `totalPitstops`, `timeLimit`, `startDelay`, `maxDrivers`, `lonely`, `canReset`, `isRemoved`) " +
+            var heatId = DB.executeInsert("INSERT INTO `ts_heats`(`roundId`, `heatNumber`, `state`, `startTime`, `endTime`, `fastestLapUUID`, `totalLaps`, `totalPitstops`, `timeLimit`, `startDelay`, `maxDrivers`, `lonely`, `canReset`, `lapReset`, `isRemoved`) " +
                     "VALUES (" +
                     round.getId() + "," +
                     heatIndex + "," +
@@ -436,6 +440,7 @@ public class MySQLDatabase implements TSDatabase, EventDatabase, TrackDatabase, 
                     "NULL," +
                     "NULL," +
                     "NULL," +
+                    "0," +
                     "0," +
                     "0," +
                     "0)");

--- a/src/main/java/me/makkuusen/timing/system/database/SQLiteDatabase.java
+++ b/src/main/java/me/makkuusen/timing/system/database/SQLiteDatabase.java
@@ -11,6 +11,7 @@ import me.makkuusen.timing.system.database.updates.Version2;
 import me.makkuusen.timing.system.database.updates.Version3;
 import me.makkuusen.timing.system.database.updates.Version4;
 import me.makkuusen.timing.system.database.updates.Version5;
+import me.makkuusen.timing.system.database.updates.Version6;
 import org.bukkit.Material;
 
 import java.io.File;
@@ -33,7 +34,7 @@ public class SQLiteDatabase extends MySQLDatabase {
         try {
             var row = DB.getFirstRow("SELECT * FROM `ts_version` ORDER BY `date` DESC;");
 
-            int databaseVersion = 5;
+            int databaseVersion = 6;
             if (row == null) { // First startup
                 DB.executeInsert("INSERT INTO `ts_version` (`version`, `date`) VALUES(" + databaseVersion + ", " + ApiUtilities.getTimestamp() + ");");
                 return true;
@@ -71,6 +72,9 @@ public class SQLiteDatabase extends MySQLDatabase {
         }
         if (previousVersion < 5) {
             Version5.updateSQLite();
+        }
+        if (previousVersion < 6) {
+            Version6.updateSQLite();
         }
     }
 
@@ -183,6 +187,7 @@ public class SQLiteDatabase extends MySQLDatabase {
                           `maxDrivers` INTEGER DEFAULT NULL,
                           `lonely` INTEGER DEFAULT NULL,
                           `canReset` INTEGER DEFAULT NULL,
+                          `lapReset` INTEGER DEFAULT NULL,
                           `isRemoved` INTEGER NOT NULL DEFAULT '0'
                         );""");
 

--- a/src/main/java/me/makkuusen/timing/system/database/updates/Version6.java
+++ b/src/main/java/me/makkuusen/timing/system/database/updates/Version6.java
@@ -1,0 +1,28 @@
+package me.makkuusen.timing.system.database.updates;
+
+import co.aikar.idb.DB;
+
+import java.sql.SQLException;
+
+public class Version6 {
+
+    public static void updateMySQL() throws SQLException {
+        try {
+            DB.executeUpdate("ALTER TABLE `ts_heats` ADD `lapReset` tinyint(1) NOT NULL DEFAULT 0 AFTER `canReset`;");
+        } catch (SQLException e) {
+            // Log the error for debugging
+            System.err.println("Failed to update MySQL schema: " + e.getMessage());
+            throw e;  // Rethrow to ensure the error is propagated correctly
+        }
+    }
+
+    public static void updateSQLite() throws SQLException {
+        try {
+            DB.executeUpdate("ALTER TABLE `ts_heats` ADD `lapReset` INTEGER NOT NULL DEFAULT 0;");
+        } catch (SQLException e) {
+            // Log the error for debugging
+            System.err.println("Failed to update SQLite schema: " + e.getMessage());
+            throw e;  // Rethrow to ensure the error is propagated correctly
+        }
+    }
+}

--- a/src/main/java/me/makkuusen/timing/system/heat/Heat.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/Heat.java
@@ -53,6 +53,7 @@ public class Heat {
     private Integer maxDrivers;
     private Boolean lonely;
     private Boolean reset;
+    private Boolean lapReset;
     private SpectatorScoreboard scoreboard;
     private Instant lastScoreboardUpdate = Instant.now();
 
@@ -70,6 +71,7 @@ public class Heat {
         maxDrivers = data.get("maxDrivers") == null ? null : data.getInt("maxDrivers");
         lonely = data.get("lonely") instanceof Boolean ? data.get("lonely") : data.get("lonely").equals(1);
         reset = data.get("canReset") instanceof Boolean ? data.get("canReset") : data.get("canReset").equals(1);
+        lapReset = data.get("lapReset") instanceof Boolean ? data.get("lapReset") : data.get("lapReset").equals(1);
         startDelay = data.get("startDelay") == null ? round instanceof FinalRound ? TimingSystem.configuration.getFinalStartDelayInMS() : TimingSystem.configuration.getQualyStartDelayInMS() : data.getInt("startDelay");
         fastestLapUUID = data.getString("fastestLapUUID") == null ? null : UUID.fromString(data.getString("fastestLapUUID"));
         gridManager = new GridManager(round instanceof QualificationRound);

--- a/src/main/java/me/makkuusen/timing/system/heat/QualifyHeat.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/QualifyHeat.java
@@ -4,6 +4,7 @@ import me.makkuusen.timing.system.ApiUtilities;
 import me.makkuusen.timing.system.TimingSystem;
 import me.makkuusen.timing.system.event.EventAnnouncements;
 import me.makkuusen.timing.system.participant.Driver;
+import me.makkuusen.timing.system.participant.DriverState;
 import me.makkuusen.timing.system.theme.Theme;
 import net.kyori.adventure.text.Component;
 
@@ -24,6 +25,13 @@ public class QualifyHeat {
             if (driver.getHeat().noDriversRunning()) {
                 driver.getHeat().finishHeat();
             }
+            return true;
+        }
+
+        if (driver.getHeat().getLapReset() == true) {
+            driver.passResetLap();
+            ApiUtilities.teleportPlayerAndSpawnBoat(driver.getTPlayer().getPlayer(), driver.getHeat().getEvent().getTrack(), driver.getHeat().getEvent().getTrack().getSpawnLocation());
+            driver.setState(DriverState.LAPRESET);
             return true;
         }
 

--- a/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
+++ b/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
@@ -2,9 +2,6 @@ package me.makkuusen.timing.system.loneliness;
 
 import me.makkuusen.timing.system.api.TimingSystemAPI;
 import me.makkuusen.timing.system.api.events.BoatSpawnEvent;
-import me.makkuusen.timing.system.event.EventAnnouncements;
-import me.makkuusen.timing.system.database.EventDatabase;
-import me.makkuusen.timing.system.sounds.PlaySound;
 import me.makkuusen.timing.system.tplayer.TPlayer;
 import org.bukkit.entity.Boat;
 import org.bukkit.entity.ChestBoat;
@@ -50,6 +47,7 @@ public class LonelinessController implements Listener {
         Runnable visibilityTask = () -> {
             for (Player player : plugin.getServer().getOnlinePlayers()) {
                 if (player.equals(ghostedPlayer)) continue; // Do not hide from themselves
+                if (!(player.getVehicle() != null && (player.getVehicle() instanceof Boat || player.getVehicle() instanceof ChestBoat))) continue; // Do not hide to spectators
 
                 Entity vehicle = ghostedPlayer.getVehicle();
                 if (vehicle != null) {
@@ -152,7 +150,7 @@ public class LonelinessController implements Listener {
         }
     }
 
-    // Event Handlers
+
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();

--- a/src/main/java/me/makkuusen/timing/system/participant/Driver.java
+++ b/src/main/java/me/makkuusen/timing/system/participant/Driver.java
@@ -98,6 +98,10 @@ public class Driver extends Participant implements Comparable<Driver> {
         newLap();
     }
 
+    public void passResetLap() {
+        finishLap();
+    }
+
     public boolean passPit() {
         if (!getCurrentLap().isPitted()) {
             setPits(pits + 1);
@@ -136,6 +140,11 @@ public class Driver extends Participant implements Comparable<Driver> {
 
     public void resetQualyLap() {
         laps.remove(laps.size() - 1);
+        state = DriverState.RUNNING;
+        newLap();
+    }
+
+    public void lapReset() {
         state = DriverState.RUNNING;
         newLap();
     }

--- a/src/main/java/me/makkuusen/timing/system/participant/DriverState.java
+++ b/src/main/java/me/makkuusen/timing/system/participant/DriverState.java
@@ -1,5 +1,5 @@
 package me.makkuusen.timing.system.participant;
 
 public enum DriverState {
-    SETUP, LOADED, STARTING, RUNNING, FINISHED, DISQUALIFIED, RESET
+    SETUP, LOADED, STARTING, RUNNING, FINISHED, DISQUALIFIED, RESET, LAPRESET
 }


### PR DESCRIPTION
- Adds /heat set lapreset which, when true, will reset drivers to the tt spot upon completing a lap
- Fixes bug with /heat set reset which would hide action bar from drivers after resetting until a new lap was started
- Fixes bug with ghosting which would hide ghosted players from spectators