### PR TITLE
Loneliness rewrite

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/ApiUtilities.java
+++ b/src/main/java/me/makkuusen/timing/system/ApiUtilities.java
@@ -704,11 +704,6 @@ public class ApiUtilities {
             }
         }
 
-        LonelinessController.updatePlayersVisibility(player);
-        if (!LonelinessController.unghost(player.getUniqueId())) {
-            LonelinessController.updatePlayerVisibility(player);
-        }
-
         if (TimeTrialController.timeTrials.containsKey(player.getUniqueId())) {
             var tt = TimeTrialController.timeTrials.get(player.getUniqueId());
             Track track = tt.getTrack();

--- a/src/main/java/me/makkuusen/timing/system/ApiUtilities.java
+++ b/src/main/java/me/makkuusen/timing/system/ApiUtilities.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import me.makkuusen.timing.system.loneliness.LonelinessController;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
@@ -701,6 +702,11 @@ public class ApiUtilities {
                 Text.send(player, Error.NOT_NOW);
                 return;
             }
+        }
+
+        LonelinessController.updatePlayersVisibility(player);
+        if (!LonelinessController.unghost(player.getUniqueId())) {
+            LonelinessController.updatePlayerVisibility(player);
         }
 
         if (TimeTrialController.timeTrials.containsKey(player.getUniqueId())) {

--- a/src/main/java/me/makkuusen/timing/system/TSListener.java
+++ b/src/main/java/me/makkuusen/timing/system/TSListener.java
@@ -191,7 +191,7 @@ public class TSListener implements Listener {
             if (event.getExited() instanceof Player player) {
                 var maybeDriver = EventDatabase.getDriverFromRunningHeat(player.getUniqueId());
                 if (maybeDriver.isPresent()) {
-                    if (maybeDriver.get().getState() == DriverState.LOADED) {
+                    if (maybeDriver.get().getState() == DriverState.LOADED || maybeDriver.get().getState() == DriverState.STARTING || maybeDriver.get().getState() == DriverState.RUNNING || maybeDriver.get().getState() == DriverState.RESET || maybeDriver.get().getState() == DriverState.LAPRESET) {
                         event.setCancelled(true);
                         return;
                     }

--- a/src/main/java/me/makkuusen/timing/system/TSListener.java
+++ b/src/main/java/me/makkuusen/timing/system/TSListener.java
@@ -175,13 +175,8 @@ public class TSListener implements Listener {
 
     @EventHandler
     public void onVehicleEnter(VehicleEnterEvent e) {
-        if (!e.getVehicle().getPassengers().isEmpty()) {
-            var passenger = e.getVehicle().getPassengers().get(0);
-            if (passenger instanceof Player player) {
-                if (TimeTrialController.timeTrials.containsKey(player.getUniqueId())) {
-                    e.setCancelled(true);
-                }
-            }
+        if (e.getVehicle() instanceof Boat boat && (boat.getPersistentDataContainer().has(Objects.requireNonNull(NamespacedKey.fromString("spawned", plugin))) || boat.getEntitySpawnReason().equals(CreatureSpawnEvent.SpawnReason.COMMAND))) {
+            e.setCancelled(true);
         }
     }
 

--- a/src/main/java/me/makkuusen/timing/system/TSListener.java
+++ b/src/main/java/me/makkuusen/timing/system/TSListener.java
@@ -175,7 +175,7 @@ public class TSListener implements Listener {
 
     @EventHandler
     public void onVehicleEnter(VehicleEnterEvent e) {
-        if (e.getVehicle() instanceof Boat boat && (boat.getPersistentDataContainer().has(Objects.requireNonNull(NamespacedKey.fromString("spawned", plugin))) || boat.getEntitySpawnReason().equals(CreatureSpawnEvent.SpawnReason.COMMAND))) {
+        if (e.getVehicle() instanceof Boat boat && (boat.getPersistentDataContainer().has(Objects.requireNonNull(NamespacedKey.fromString("spawned", plugin))) || boat.getEntitySpawnReason().equals(CreatureSpawnEvent.SpawnReason.COMMAND)) && !e.getVehicle().getPassengers().isEmpty()) {
             e.setCancelled(true);
         }
     }

--- a/src/main/java/me/makkuusen/timing/system/TimingSystem.java
+++ b/src/main/java/me/makkuusen/timing/system/TimingSystem.java
@@ -127,6 +127,7 @@ public class TimingSystem extends JavaPlugin {
         manager.registerCommand(new CommandTimeTrialRandom());
         manager.registerCommand(new CommandTimeTrialCancel());
         manager.registerCommand(new CommandGhost());
+        manager.registerCommand(new CommandUnghost());
         taskChainFactory = BukkitTaskChainFactory.create(this);
 
         database = configuration.getDatabaseType();

--- a/src/main/java/me/makkuusen/timing/system/commands/CommandGhost.java
+++ b/src/main/java/me/makkuusen/timing/system/commands/CommandGhost.java
@@ -26,7 +26,7 @@ public class CommandGhost extends BaseCommand {
         TPlayer tPlayer = TSDatabase.getPlayer(target.getUniqueId());
         Boolean isGhosted = LonelinessController.isGhosted(target.getUniqueId());
 
-        var maybeDriver = TimingSystemAPI.getDriverFromRunningHeat(player.getUniqueId());
+        var maybeDriver = TimingSystemAPI.getDriverFromRunningHeat(target.getUniqueId());
         if (!maybeDriver.isPresent()) {
             Text.send(player, Error.NOT_NOW);
             return;
@@ -40,7 +40,7 @@ public class CommandGhost extends BaseCommand {
             return;
         }
 
-        ghost(player.getUniqueId());
+        ghost(target.getUniqueId());
 
         Text.send(player, Success.GHOSTING_ON);
         Text.send(target, Warning.GHOSTING_TARGET_ON);

--- a/src/main/java/me/makkuusen/timing/system/commands/CommandRace.java
+++ b/src/main/java/me/makkuusen/timing/system/commands/CommandRace.java
@@ -86,13 +86,11 @@ public class CommandRace extends BaseCommand {
         }
 
         if (!track.getTrackRegions().hasRegion(TrackRegion.RegionType.START)) {
-            Bukkit.getLogger().info("1");
             Text.send(player, Error.GENERIC);
             return;
         }
 
         if (!track.getTrackLocations().hasLocation(TrackLocation.Type.GRID)) {
-            Bukkit.getLogger().info("2");
             Text.send(player, Error.GENERIC);
             return;
         }
@@ -101,7 +99,6 @@ public class CommandRace extends BaseCommand {
         String name = "QuickRace";
         var maybeEvent = EventDatabase.eventNew(player.getUniqueId(), name);
         if (maybeEvent.isEmpty()) {
-            Bukkit.getLogger().info("3");
             Text.send(player, Error.GENERIC);
             return;
         }
@@ -117,7 +114,6 @@ public class CommandRace extends BaseCommand {
         var maybeRound = event.getEventSchedule().getRound(1);
 
         if (maybeRound.isEmpty()) {
-            Bukkit.getLogger().info("4");
             Text.send(player, Error.GENERIC);
             return;
         }

--- a/src/main/java/me/makkuusen/timing/system/commands/CommandRace.java
+++ b/src/main/java/me/makkuusen/timing/system/commands/CommandRace.java
@@ -86,11 +86,13 @@ public class CommandRace extends BaseCommand {
         }
 
         if (!track.getTrackRegions().hasRegion(TrackRegion.RegionType.START)) {
+            Bukkit.getLogger().info("1");
             Text.send(player, Error.GENERIC);
             return;
         }
 
         if (!track.getTrackLocations().hasLocation(TrackLocation.Type.GRID)) {
+            Bukkit.getLogger().info("2");
             Text.send(player, Error.GENERIC);
             return;
         }
@@ -99,6 +101,7 @@ public class CommandRace extends BaseCommand {
         String name = "QuickRace";
         var maybeEvent = EventDatabase.eventNew(player.getUniqueId(), name);
         if (maybeEvent.isEmpty()) {
+            Bukkit.getLogger().info("3");
             Text.send(player, Error.GENERIC);
             return;
         }
@@ -114,6 +117,7 @@ public class CommandRace extends BaseCommand {
         var maybeRound = event.getEventSchedule().getRound(1);
 
         if (maybeRound.isEmpty()) {
+            Bukkit.getLogger().info("4");
             Text.send(player, Error.GENERIC);
             return;
         }

--- a/src/main/java/me/makkuusen/timing/system/commands/CommandReset.java
+++ b/src/main/java/me/makkuusen/timing/system/commands/CommandReset.java
@@ -51,32 +51,41 @@ public class CommandReset extends BaseCommand {
                 ApiUtilities.teleportPlayerAndSpawnBoat(driver.getTPlayer().getPlayer(), driver.getHeat().getEvent().getTrack(), driver.getHeat().getEvent().getTrack().getSpawnLocation());
                 driver.setState(DriverState.RESET);
             } else {
-                Text.send(player, Error.NOT_NOW);
-            }
-        } else if (round instanceof FinalRound) {
-
-            if (driver.getState() == DriverState.RUNNING) {
-                int latestCheckpoint = driver.getCurrentLap().getLatestCheckpoint();
-
-                if (latestCheckpoint == 0) {
-                    Location startLineLocation = driver.getHeat().getEvent().getTrack().getTrackRegions().getRegions(TrackRegion.RegionType.START).get(0).getSpawnLocation();
-                    ApiUtilities.teleportPlayerAndSpawnBoat(driver.getTPlayer().getPlayer(), driver.getHeat().getEvent().getTrack(), startLineLocation);
+                boolean success = resetCheck(driver);
+                if (!success) {
+                    Text.send(player, Error.NOT_NOW);
                     return;
                 }
-
-                ApiUtilities.teleportPlayerAndSpawnBoat(driver.getTPlayer().getPlayer(), driver.getHeat().getEvent().getTrack(), driver.getHeat().getEvent().getTrack().getTrackRegions().getCheckpoints(latestCheckpoint).get(0).getSpawnLocation());
-                return;
             }
-
-            if (driver.getState() == DriverState.STARTING) {
-                Track track = driver.getHeat().getEvent().getTrack();
-                int numGrids = track.getTrackLocations().getLocations(TrackLocation.Type.GRID).size();
-                Location finalGridLocation = track.getTrackLocations().getLocations(TrackLocation.Type.GRID).get(numGrids - 1).getLocation();
-                ApiUtilities.teleportPlayerAndSpawnBoat(driver.getTPlayer().getPlayer(), driver.getHeat().getEvent().getTrack(), finalGridLocation);
-            }
-
+        } else if (round instanceof FinalRound) {
+            resetCheck(driver);
         } else {
             Text.send(player, Error.NOT_NOW);
         }
+    }
+
+    private static boolean resetCheck(Driver driver) {
+        if (driver.getState() == DriverState.RUNNING) {
+            int latestCheckpoint = driver.getCurrentLap().getLatestCheckpoint();
+
+            if (latestCheckpoint == 0) {
+                Location startLineLocation = driver.getHeat().getEvent().getTrack().getTrackRegions().getRegions(TrackRegion.RegionType.START).get(0).getSpawnLocation();
+                ApiUtilities.teleportPlayerAndSpawnBoat(driver.getTPlayer().getPlayer(), driver.getHeat().getEvent().getTrack(), startLineLocation);
+                return true;
+            }
+
+            ApiUtilities.teleportPlayerAndSpawnBoat(driver.getTPlayer().getPlayer(), driver.getHeat().getEvent().getTrack(), driver.getHeat().getEvent().getTrack().getTrackRegions().getCheckpoints(latestCheckpoint).get(0).getSpawnLocation());
+            return true;
+        }
+
+        if (driver.getState() == DriverState.STARTING) {
+            Track track = driver.getHeat().getEvent().getTrack();
+            int numGrids = track.getTrackLocations().getLocations(TrackLocation.Type.GRID).size();
+            Location finalGridLocation = track.getTrackLocations().getLocations(TrackLocation.Type.GRID).get(numGrids - 1).getLocation();
+            ApiUtilities.teleportPlayerAndSpawnBoat(driver.getTPlayer().getPlayer(), driver.getHeat().getEvent().getTrack(), finalGridLocation);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/main/java/me/makkuusen/timing/system/commands/CommandReset.java
+++ b/src/main/java/me/makkuusen/timing/system/commands/CommandReset.java
@@ -12,6 +12,11 @@ import me.makkuusen.timing.system.round.FinalRound;
 import me.makkuusen.timing.system.round.QualificationRound;
 import me.makkuusen.timing.system.theme.Text;
 import me.makkuusen.timing.system.theme.messages.Error;
+import me.makkuusen.timing.system.track.Track;
+import me.makkuusen.timing.system.track.locations.TrackLocation;
+import me.makkuusen.timing.system.track.regions.TrackRegion;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
 import static me.makkuusen.timing.system.heat.QualifyHeat.timeIsOver;
@@ -49,7 +54,27 @@ public class CommandReset extends BaseCommand {
                 Text.send(player, Error.NOT_NOW);
             }
         } else if (round instanceof FinalRound) {
-            // reset to the last checkpoint
+
+            if (driver.getState() == DriverState.RUNNING) {
+                int latestCheckpoint = driver.getCurrentLap().getLatestCheckpoint();
+
+                if (latestCheckpoint == 0) {
+                    Location startLineLocation = driver.getHeat().getEvent().getTrack().getTrackRegions().getRegions(TrackRegion.RegionType.START).get(0).getSpawnLocation();
+                    ApiUtilities.teleportPlayerAndSpawnBoat(driver.getTPlayer().getPlayer(), driver.getHeat().getEvent().getTrack(), startLineLocation);
+                    return;
+                }
+
+                ApiUtilities.teleportPlayerAndSpawnBoat(driver.getTPlayer().getPlayer(), driver.getHeat().getEvent().getTrack(), driver.getHeat().getEvent().getTrack().getTrackRegions().getCheckpoints(latestCheckpoint).get(0).getSpawnLocation());
+                return;
+            }
+
+            if (driver.getState() == DriverState.STARTING) {
+                Track track = driver.getHeat().getEvent().getTrack();
+                int numGrids = track.getTrackLocations().getLocations(TrackLocation.Type.GRID).size();
+                Location finalGridLocation = track.getTrackLocations().getLocations(TrackLocation.Type.GRID).get(numGrids - 1).getLocation();
+                ApiUtilities.teleportPlayerAndSpawnBoat(driver.getTPlayer().getPlayer(), driver.getHeat().getEvent().getTrack(), finalGridLocation);
+            }
+
         } else {
             Text.send(player, Error.NOT_NOW);
         }

--- a/src/main/java/me/makkuusen/timing/system/commands/CommandSettings.java
+++ b/src/main/java/me/makkuusen/timing/system/commands/CommandSettings.java
@@ -57,22 +57,6 @@ public class CommandSettings extends BaseCommand {
         Text.send(player, tPlayer.getSettings().isVerbose() ? Success.CHECKPOINTS_ANNOUNCEMENTS_ON : Success.CHECKPOINTS_ANNOUNCEMENTS_OFF);
     }
 
-    @Subcommand("lonely")
-    @CommandPermission("%permissiontimingsystem_settings")
-    public static void onLonely(Player player) {
-        var tPlayer = TSDatabase.getPlayer(player);
-
-        for (Driver driver : playerInRunningHeat.values()) {
-            if (driver.getTPlayer().getUniqueId().equals(player.getUniqueId())) {
-                Text.send(player, Error.PERMISSION_DENIED);
-                return;
-            }
-        }
-
-        tPlayer.getSettings().toggleLonely();
-        Text.send(player, tPlayer.getSettings().isLonely() ? Success.LONELY_ON : Success.LONELY_OFF);
-    }
-
     @Subcommand("boat")
     @CommandCompletion("@boat")
     @CommandPermission("%permissiontimingsystem_settings")

--- a/src/main/java/me/makkuusen/timing/system/commands/CommandUnghost.java
+++ b/src/main/java/me/makkuusen/timing/system/commands/CommandUnghost.java
@@ -2,11 +2,8 @@ package me.makkuusen.timing.system.commands;
 
 import co.aikar.commands.BaseCommand;
 import co.aikar.commands.annotation.*;
-import me.makkuusen.timing.system.api.TimingSystemAPI;
 import me.makkuusen.timing.system.database.TSDatabase;
-import me.makkuusen.timing.system.heat.Heat;
 import me.makkuusen.timing.system.loneliness.LonelinessController;
-import me.makkuusen.timing.system.participant.Driver;
 import me.makkuusen.timing.system.theme.Text;
 import me.makkuusen.timing.system.theme.messages.Error;
 import me.makkuusen.timing.system.theme.messages.Success;
@@ -14,35 +11,23 @@ import me.makkuusen.timing.system.theme.messages.Warning;
 import me.makkuusen.timing.system.tplayer.TPlayer;
 import org.bukkit.entity.Player;
 
-import static me.makkuusen.timing.system.loneliness.LonelinessController.ghost;
+import static me.makkuusen.timing.system.loneliness.LonelinessController.unghost;
 
-@CommandAlias("ghost|gh")
-public class CommandGhost extends BaseCommand {
+@CommandAlias("unghost|ugh")
+public class CommandUnghost extends BaseCommand {
     @Default
     @CommandCompletion("@players")
     @CommandPermission("%permissiontimingsystem_ghost")
-    public static void onGhost(Player player, String targetName) {
+    public static void onUnghost(Player player, String targetName) {
         Player target = player.getServer().getPlayer(targetName);
         TPlayer tPlayer = TSDatabase.getPlayer(target.getUniqueId());
         Boolean isGhosted = LonelinessController.isGhosted(target.getUniqueId());
 
-        var maybeDriver = TimingSystemAPI.getDriverFromRunningHeat(player.getUniqueId());
-        if (!maybeDriver.isPresent()) {
+        if (unghost(player.getUniqueId())) {
+            Text.send(player, Success.GHOSTING_OFF);
+            Text.send(target, Warning.GHOSTING_TARGET_OFF);
+        } else {
             Text.send(player, Error.NOT_NOW);
-            return;
         }
-
-        Driver driver = maybeDriver.get();
-        Heat heat = driver.getHeat();
-
-        if (heat.getLonely()) {
-            Text.send(player, Error.NOT_NOW);
-            return;
-        }
-
-        ghost(player.getUniqueId());
-
-        Text.send(player, Success.GHOSTING_ON);
-        Text.send(target, Warning.GHOSTING_TARGET_ON);
     }
 }

--- a/src/main/java/me/makkuusen/timing/system/database/MySQLDatabase.java
+++ b/src/main/java/me/makkuusen/timing/system/database/MySQLDatabase.java
@@ -9,6 +9,7 @@ import me.makkuusen.timing.system.database.updates.Version3;
 import me.makkuusen.timing.system.database.updates.Version4;
 import me.makkuusen.timing.system.database.updates.Version5;
 import me.makkuusen.timing.system.database.updates.Version6;
+import me.makkuusen.timing.system.database.updates.Version7;
 import me.makkuusen.timing.system.event.Event;
 import me.makkuusen.timing.system.heat.Heat;
 import me.makkuusen.timing.system.heat.HeatState;
@@ -61,7 +62,7 @@ public class MySQLDatabase implements TSDatabase, EventDatabase, TrackDatabase, 
         try {
             var row = DB.getFirstRow("SELECT * FROM `ts_version` ORDER BY `date` DESC;");
 
-            int databaseVersion = 6;
+            int databaseVersion = 7;
             if (row == null) { // First startup
                 DB.executeInsert("INSERT INTO `ts_version` (`version`, `date`) VALUES(?, ?);",
                         databaseVersion,
@@ -127,6 +128,9 @@ public class MySQLDatabase implements TSDatabase, EventDatabase, TrackDatabase, 
         if (previousVersion < 6) {
             Version6.updateMySQL();
         }
+        if (previousVersion < 7) {
+            Version7.updateMySQL();
+        }
     }
 
 
@@ -140,7 +144,6 @@ public class MySQLDatabase implements TSDatabase, EventDatabase, TrackDatabase, 
                       `shortName` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
                       `boat` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
                       `verbose` tinyint(1) NOT NULL DEFAULT '0',
-                      `lonely` tinyint(1) NOT NULL DEFAULT '0',
                       `timetrial` tinyint(1) NOT NULL DEFAULT '1',
                       `override` tinyint(1) NOT NULL DEFAULT '0',
                       `chestBoat` tinyint(1) NOT NULL DEFAULT '0',

--- a/src/main/java/me/makkuusen/timing/system/database/SQLiteDatabase.java
+++ b/src/main/java/me/makkuusen/timing/system/database/SQLiteDatabase.java
@@ -12,6 +12,7 @@ import me.makkuusen.timing.system.database.updates.Version3;
 import me.makkuusen.timing.system.database.updates.Version4;
 import me.makkuusen.timing.system.database.updates.Version5;
 import me.makkuusen.timing.system.database.updates.Version6;
+import me.makkuusen.timing.system.database.updates.Version7;
 import org.bukkit.Material;
 
 import java.io.File;
@@ -34,7 +35,7 @@ public class SQLiteDatabase extends MySQLDatabase {
         try {
             var row = DB.getFirstRow("SELECT * FROM `ts_version` ORDER BY `date` DESC;");
 
-            int databaseVersion = 6;
+            int databaseVersion = 7;
             if (row == null) { // First startup
                 DB.executeInsert("INSERT INTO `ts_version` (`version`, `date`) VALUES(?, ?);",
                         databaseVersion,
@@ -85,6 +86,10 @@ public class SQLiteDatabase extends MySQLDatabase {
         if (previousVersion < 6) {
             Version6.updateSQLite();
         }
+
+        if (previousVersion < 7) {
+            Version7.updateSQLite();
+        }
     }
 
 
@@ -102,7 +107,6 @@ public class SQLiteDatabase extends MySQLDatabase {
                         `compactScoreboard` INTEGER NOT NULL DEFAULT 0,
                         `override` INTEGER NOT NULL DEFAULT 0,
                         `verbose` INTEGER NOT NULL DEFAULT 0,
-                        `lonely` INTEGER NOT NULL DEFAULT 0,
                         `timetrial` INTEGER NOT NULL DEFAULT 1,
                         `toggleSound` INTEGER DEFAULT 1 NOT NULL,
                         `sendFinalLaps` INTEGER DEFAULT 0 NOT NULL

--- a/src/main/java/me/makkuusen/timing/system/database/updates/Version7.java
+++ b/src/main/java/me/makkuusen/timing/system/database/updates/Version7.java
@@ -1,0 +1,27 @@
+package me.makkuusen.timing.system.database.updates;
+
+import co.aikar.idb.DB;
+
+import java.sql.SQLException;
+
+public class Version7 {
+    public static void updateMySQL() throws SQLException {
+        try {
+            DB.executeUpdate("ALTER TABLE `ts_players` DROP COLUMN `canReset` tinyint(1) NOT NULL DEFAULT 0 AFTER `lonely`;");
+        } catch (SQLException e) {
+            // Log the error for debugging
+            System.err.println("Failed to update MySQL schema: " + e.getMessage());
+            throw e;  // Rethrow to ensure the error is propagated correctly
+        }
+    }
+
+    public static void updateSQLite() throws SQLException {
+        try {
+            DB.executeUpdate("ALTER TABLE `ts_players` DROP COLUMN `canReset` INTEGER NOT NULL DEFAULT 0;");
+        } catch (SQLException e) {
+            // Log the error for debugging
+            System.err.println("Failed to update SQLite schema: " + e.getMessage());
+            throw e;  // Rethrow to ensure the error is propagated correctly
+        }
+    }
+}

--- a/src/main/java/me/makkuusen/timing/system/database/updates/Version7.java
+++ b/src/main/java/me/makkuusen/timing/system/database/updates/Version7.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 public class Version7 {
     public static void updateMySQL() throws SQLException {
         try {
-            DB.executeUpdate("ALTER TABLE `ts_players` DROP COLUMN `canReset` tinyint(1) NOT NULL DEFAULT 0 AFTER `lonely`;");
+            DB.executeUpdate("ALTER TABLE `ts_players` DROP COLUMN `lonely`;");
         } catch (SQLException e) {
             // Log the error for debugging
             System.err.println("Failed to update MySQL schema: " + e.getMessage());
@@ -17,7 +17,7 @@ public class Version7 {
 
     public static void updateSQLite() throws SQLException {
         try {
-            DB.executeUpdate("ALTER TABLE `ts_players` DROP COLUMN `canReset` INTEGER NOT NULL DEFAULT 0;");
+            DB.executeUpdate("ALTER TABLE `ts_players` DROP COLUMN `lonely`;");
         } catch (SQLException e) {
             // Log the error for debugging
             System.err.println("Failed to update SQLite schema: " + e.getMessage());

--- a/src/main/java/me/makkuusen/timing/system/heat/GridManager.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/GridManager.java
@@ -36,9 +36,17 @@ public class GridManager {
         if (player != null) {
             Location grid;
             if (qualyGrid) {
-                grid = track.getTrackLocations().getLocation(TrackLocation.Type.QUALYGRID, driver.getStartPosition()).get().getLocation();
+                if (driver.getHeat().getLonely()) {
+                    grid = track.getTrackLocations().getLocation(TrackLocation.Type.QUALYGRID, 1).get().getLocation();
+                } else {
+                    grid = track.getTrackLocations().getLocation(TrackLocation.Type.QUALYGRID, driver.getStartPosition()).get().getLocation();
+                }
             } else {
-                grid = track.getTrackLocations().getLocation(TrackLocation.Type.GRID, driver.getStartPosition()).get().getLocation();
+                if (driver.getHeat().getLonely()) {
+                    grid = track.getTrackLocations().getLocation(TrackLocation.Type.GRID, 1).get().getLocation();
+                } else {
+                    grid = track.getTrackLocations().getLocation(TrackLocation.Type.GRID, driver.getStartPosition()).get().getLocation();
+                }
             }
             if (grid != null) {
                 teleportPlayerToGrid(player, grid, track);

--- a/src/main/java/me/makkuusen/timing/system/heat/GridManager.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/GridManager.java
@@ -4,6 +4,7 @@ import co.aikar.taskchain.TaskChain;
 import me.makkuusen.timing.system.ApiUtilities;
 import me.makkuusen.timing.system.TimingSystem;
 import me.makkuusen.timing.system.api.TimingSystemAPI;
+import me.makkuusen.timing.system.loneliness.LonelinessController;
 import me.makkuusen.timing.system.participant.Driver;
 import me.makkuusen.timing.system.participant.DriverState;
 import me.makkuusen.timing.system.timetrial.TimeTrialController;
@@ -29,7 +30,7 @@ public class GridManager {
         this.qualy = qualy;
     }
 
-    public void putDriverOnGrid(Driver driver, Track track, Boolean lonely) {
+    public void putDriverOnGrid(Driver driver, Track track) {
         boolean qualyGrid = qualy && !track.getTrackLocations().getLocations(TrackLocation.Type.QUALYGRID).isEmpty();
         Player player = driver.getTPlayer().getPlayer();
         if (player != null) {
@@ -40,13 +41,15 @@ public class GridManager {
                 grid = track.getTrackLocations().getLocation(TrackLocation.Type.GRID, driver.getStartPosition()).get().getLocation();
             }
             if (grid != null) {
-                teleportPlayerToGrid(player, grid, track, lonely);
+                teleportPlayerToGrid(player, grid, track);
             }
         }
         driver.setState(DriverState.LOADED);
+        LonelinessController.updatePlayersVisibility(driver.getTPlayer().getPlayer());
+        LonelinessController.updatePlayerVisibility(driver.getTPlayer().getPlayer());
     }
 
-    private void teleportPlayerToGrid(Player player, Location location, Track track, Boolean lonely) {
+    private void teleportPlayerToGrid(Player player, Location location, Track track) {
         location.setPitch(player.getLocation().getPitch());
         if (!location.isWorldLoaded()) {
             return;
@@ -62,7 +65,6 @@ public class GridManager {
         ar.setCanMove(false);
         ar.setGravity(false);
         ar.setVisible(false);
-        TimingSystemAPI.getTPlayer(player.getUniqueId()).getSettings().setLonely(lonely);
         Bukkit.getScheduler().runTaskLater(TimingSystem.getPlugin(), () -> {
             TimeTrialController.lastTimeTrialTrack.put(player.getUniqueId(), track);
             Boat boat = ApiUtilities.spawnBoatAndAddPlayerWithBoatUtils(player, location, track, false);

--- a/src/main/java/me/makkuusen/timing/system/heat/Heat.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/Heat.java
@@ -12,6 +12,7 @@ import me.makkuusen.timing.system.database.EventDatabase;
 import me.makkuusen.timing.system.event.Event;
 import me.makkuusen.timing.system.event.EventAnnouncements;
 import me.makkuusen.timing.system.event.EventResults;
+import me.makkuusen.timing.system.loneliness.LonelinessController;
 import me.makkuusen.timing.system.participant.Driver;
 import me.makkuusen.timing.system.participant.DriverState;
 import me.makkuusen.timing.system.participant.Participant;
@@ -123,7 +124,7 @@ public class Heat {
     private void setDriverOnGrid(Driver driver) {
         DriverPlacedOnGrid event = new DriverPlacedOnGrid(driver, this);
         Bukkit.getServer().getPluginManager().callEvent(event);
-        gridManager.putDriverOnGrid(driver, getEvent().getTrack(), lonely);
+        gridManager.putDriverOnGrid(driver, getEvent().getTrack());
         EventDatabase.addPlayerToRunningHeat(driver);
     }
 
@@ -211,6 +212,10 @@ public class Heat {
                     driver.setEndTime(TimingSystem.currentTime);
                 }
                 driver.setState(DriverState.FINISHED);
+                LonelinessController.updatePlayersVisibility(driver.getTPlayer().getPlayer());
+                if (!LonelinessController.unghost(driver.getTPlayer().getUniqueId())) {
+                    LonelinessController.updatePlayerVisibility(driver.getTPlayer().getPlayer());
+                }
             }
         });
 
@@ -303,6 +308,10 @@ public class Heat {
                 d.setPosition(d.getPosition() - 1);
             }
         }
+        LonelinessController.updatePlayersVisibility(driver.getTPlayer().getPlayer());
+        if (!LonelinessController.unghost(driver.getTPlayer().getUniqueId())) {
+            LonelinessController.updatePlayerVisibility(driver.getTPlayer().getPlayer());
+        }
         return true;
     }
 
@@ -343,6 +352,10 @@ public class Heat {
         EventDatabase.removePlayerFromRunningHeat(driver.getTPlayer().getUniqueId());
         if (noDriversRunning()) {
             finishHeat();
+        }
+        LonelinessController.updatePlayersVisibility(driver.getTPlayer().getPlayer());
+        if (!LonelinessController.unghost(driver.getTPlayer().getUniqueId())) {
+            LonelinessController.updatePlayerVisibility(driver.getTPlayer().getPlayer());
         }
         return true;
     }

--- a/src/main/java/me/makkuusen/timing/system/heat/Heat.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/Heat.java
@@ -217,6 +217,10 @@ public class Heat {
                     LonelinessController.updatePlayerVisibility(driver.getTPlayer().getPlayer());
                 }
             }
+            LonelinessController.updatePlayersVisibility(driver.getTPlayer().getPlayer());
+            if (!LonelinessController.unghost(driver.getTPlayer().getUniqueId())) {
+                LonelinessController.updatePlayerVisibility(driver.getTPlayer().getPlayer());
+            }
         });
 
         //Dump all laps to database
@@ -257,6 +261,10 @@ public class Heat {
         getDrivers().values().forEach(driver -> {
             driver.reset();
             EventDatabase.removePlayerFromRunningHeat(driver.getTPlayer().getUniqueId());
+            LonelinessController.updatePlayersVisibility(driver.getTPlayer().getPlayer());
+            if (!LonelinessController.unghost(driver.getTPlayer().getUniqueId())) {
+                LonelinessController.updatePlayerVisibility(driver.getTPlayer().getPlayer());
+            }
         });
         if (scoreboard != null) {
             scoreboard.removeScoreboards();

--- a/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
+++ b/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
@@ -131,12 +131,11 @@ public class LonelinessController implements Listener {
     }
 
     public static void updatePlayerVisibility(Player player) {
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+         Bukkit.getScheduler().runTaskLater(plugin, () -> {
             for (Player p : plugin.getServer().getOnlinePlayers()) {
                 if (p.getUniqueId().equals(player.getUniqueId())) {
                     continue;
                 }
-
                 // if p is not in a boat there is no situation where they should not see player
                 if (!(p.getVehicle() instanceof Boat) && !(p.getVehicle() instanceof ChestBoat)) {
                     if (player.getVehicle() instanceof Boat || player.getVehicle() instanceof ChestBoat) {
@@ -179,6 +178,26 @@ public class LonelinessController implements Listener {
                     continue;
                 }
 
+                maybeDriver = TimingSystemAPI.getDriverFromRunningHeat(player.getUniqueId());
+
+                if (!maybeDriver.isPresent()) {
+                    if (player.getVehicle() instanceof Boat || player.getVehicle() instanceof ChestBoat) {
+                        p.hideEntity(plugin, player.getVehicle());
+                    }
+
+                    p.hideEntity(plugin, player);
+                    continue;
+                }
+
+                if (maybeDriver.get().getHeat().getId() != heat.getId()) {
+                    if (player.getVehicle() instanceof Boat || player.getVehicle() instanceof ChestBoat) {
+                        p.hideEntity(plugin, player.getVehicle());
+                    }
+
+                    p.hideEntity(plugin, player);
+                    continue;
+                }
+
                 if (heat.getLonely()) {
                     if (player.getVehicle() instanceof Boat || player.getVehicle() instanceof ChestBoat) {
                         p.hideEntity(plugin, player.getVehicle());
@@ -203,7 +222,7 @@ public class LonelinessController implements Listener {
 
                 p.showEntity(plugin, player);
             }
-        }, 5L);
+         }, 5L);
     }
 
 
@@ -224,7 +243,7 @@ public class LonelinessController implements Listener {
         updatePlayerVisibility(player);
     }
 
-    @EventHandler
+   @EventHandler
     public void onVehicleEnter(VehicleEnterEvent event) {
         if (event.getVehicle() instanceof Boat || event.getVehicle() instanceof ChestBoat) {
             if (event.getEntered() instanceof Player) {
@@ -261,10 +280,12 @@ public class LonelinessController implements Listener {
 
     @EventHandler
     public void onBoatSpawn(BoatSpawnEvent event) {
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
-            Player player = event.getPlayer();
-            updatePlayerVisibility(player);
-        }, 5L);
+        if (event.getPlayer() == null) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        updatePlayerVisibility(player);
     }
 
     public static boolean isGhosted(UUID player) {

--- a/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
+++ b/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
@@ -222,6 +222,10 @@ public class LonelinessController implements Listener {
 
    @EventHandler
     public void onVehicleEnter(VehicleEnterEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+
         if (event.getVehicle() instanceof Boat || event.getVehicle() instanceof ChestBoat) {
             if (event.getEntered() instanceof Player) {
                 Player player = (Player) event.getEntered();
@@ -233,6 +237,10 @@ public class LonelinessController implements Listener {
 
     @EventHandler
     public void onVehicleExit(VehicleExitEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+
         if (event.getVehicle() instanceof Boat || event.getVehicle() instanceof ChestBoat) {
             if (event.getExited() instanceof Player) {
                 Player player = (Player) event.getExited();

--- a/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
+++ b/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
@@ -1,9 +1,11 @@
 package me.makkuusen.timing.system.loneliness;
 
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
+import me.makkuusen.timing.system.api.events.BoatSpawnEvent;
 import me.makkuusen.timing.system.heat.Heat;
 import me.makkuusen.timing.system.heat.HeatState;
 import me.makkuusen.timing.system.participant.Driver;
@@ -129,53 +131,79 @@ public class LonelinessController implements Listener {
     }
 
     public static void updatePlayerVisibility(Player player) {
-        for (Player p : plugin.getServer().getOnlinePlayers()) {
-            if (p.getUniqueId().equals(player.getUniqueId())) {
-                continue;
-            }
-
-            // if p is not in a boat there is no situation where they should not see player
-            if (!(p.getVehicle() instanceof Boat) && !(p.getVehicle() instanceof ChestBoat)) {
-                p.showEntity(plugin, player);
-                continue;
-            }
-
-            if (TimeTrialController.timeTrials.containsKey(p.getUniqueId())) {
-                if (player.getVehicle() instanceof Boat || player.getVehicle() instanceof ChestBoat) {
-                    p.hideEntity(plugin, player.getVehicle());
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            for (Player p : plugin.getServer().getOnlinePlayers()) {
+                if (p.getUniqueId().equals(player.getUniqueId())) {
+                    continue;
                 }
 
-                p.hideEntity(plugin, player);
-                continue;
-            }
+                // if p is not in a boat there is no situation where they should not see player
+                if (!(p.getVehicle() instanceof Boat) && !(p.getVehicle() instanceof ChestBoat)) {
+                    if (player.getVehicle() instanceof Boat || player.getVehicle() instanceof ChestBoat) {
+                        p.showEntity(plugin, player.getVehicle());
+                    }
 
-            var maybeDriver = TimingSystemAPI.getDriverFromRunningHeat(p.getUniqueId());
-            if (!maybeDriver.isPresent()) {
+                    p.showEntity(plugin, player);
+                    continue;
+                }
+
+                if (TimeTrialController.timeTrials.containsKey(p.getUniqueId())) {
+                    if (player.getVehicle() instanceof Boat || player.getVehicle() instanceof ChestBoat) {
+                        p.hideEntity(plugin, player.getVehicle());
+                    }
+
+                    p.hideEntity(plugin, player);
+                    continue;
+                }
+
+                var maybeDriver = TimingSystemAPI.getDriverFromRunningHeat(p.getUniqueId());
+                if (!maybeDriver.isPresent()) {
+                    if (player.getVehicle() instanceof Boat || player.getVehicle() instanceof ChestBoat) {
+                        p.showEntity(plugin, player.getVehicle());
+                    }
+
+                    p.showEntity(plugin, player);
+                    continue;
+                }
+
+                Driver d = maybeDriver.get();
+                Heat heat = d.getHeat();
+
+                // Driver is not participating
+                if (d.getState() == DriverState.DISQUALIFIED || d.getState() == DriverState.SETUP || d.getState() == DriverState.FINISHED) {
+                    if (player.getVehicle() instanceof Boat || player.getVehicle() instanceof ChestBoat) {
+                        p.showEntity(plugin, player.getVehicle());
+                    }
+
+                    p.showEntity(plugin, player);
+                    continue;
+                }
+
+                if (heat.getLonely()) {
+                    if (player.getVehicle() instanceof Boat || player.getVehicle() instanceof ChestBoat) {
+                        p.hideEntity(plugin, player.getVehicle());
+                    }
+
+                    p.hideEntity(plugin, player);
+                    continue;
+                }
+
+                if (ghostedPlayers.contains(player.getUniqueId())) {
+                    if (player.getVehicle() instanceof Boat || player.getVehicle() instanceof ChestBoat) {
+                        p.hideEntity(plugin, player.getVehicle());
+                    }
+
+                    p.hideEntity(plugin, player);
+                    continue;
+                }
+
+                if (player.getVehicle() instanceof Boat || player.getVehicle() instanceof ChestBoat) {
+                    p.showEntity(plugin, player.getVehicle());
+                }
+
                 p.showEntity(plugin, player);
-                continue;
             }
-
-            Driver d = maybeDriver.get();
-            Heat heat = d.getHeat();
-
-            // Driver is not participating
-            if (d.getState() == DriverState.DISQUALIFIED || d.getState() == DriverState.SETUP || d.getState() == DriverState.FINISHED) {
-                p.showEntity(plugin, player);
-                continue;
-            }
-
-            if (heat.getLonely()) {
-                p.hideEntity(plugin, player);
-                continue;
-            }
-
-            if (ghostedPlayers.contains(player.getUniqueId())) {
-                p.hideEntity(plugin, player);
-                continue;
-            }
-
-            p.showEntity(plugin, player);
-        }
+        }, 5L);
     }
 
 
@@ -229,6 +257,14 @@ public class LonelinessController implements Listener {
         Player player = event.getPlayer();
 
         updatePlayersVisibility(player);
+    }
+
+    @EventHandler
+    public void onBoatSpawn(BoatSpawnEvent event) {
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            Player player = event.getPlayer();
+            updatePlayerVisibility(player);
+        }, 5L);
     }
 
     public static boolean isGhosted(UUID player) {

--- a/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
+++ b/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
@@ -37,17 +37,6 @@ public class LonelinessController implements Listener {
     public LonelinessController(Plugin plugin) {
         LonelinessController.plugin = plugin;
     }
-
-    /*
-     * players should be hidden following this logic:
-     * 
-     * on starting a time trial, all players and their vehicles should be hidden from the player
-     * if the player is in a loneliness heat, all players and their vehicles should be hidden from the player
-     * if the player is in a heat without loneliness, all players not also in the heat and their vehicles should be hidden from the player
-     *     - there is an exception to this rule: if another player in the heat is "ghosted", then that player and their vehicles should be hidden
-     * if a player is not in a boat, every player and their vehicle should be visible
-     */ 
-
     
     public static void updatePlayersVisibility(Player player) {
 
@@ -224,18 +213,6 @@ public class LonelinessController implements Listener {
             }
          }, 5L);
     }
-
-
-     /*
-     * this logic will need to be checked in the following events:
-     * - Player joins the server 1
-     * - Player joins a heat 1
-     * - Player starts a time trial 1
-     * - Player quits/finishes a heat 1
-     * - Player changes world 1
-     * - Player enters a vehicle 1
-     * - Player leaves a vehicle 1
-     */
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {

--- a/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
+++ b/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
@@ -78,6 +78,10 @@ public class LonelinessController implements Listener {
                 // Do not hide players in the same non loneliness heat, unless they are ghosted
                 maybeDriver = TimingSystemAPI.getDriverFromRunningHeat(p.getUniqueId());
                 if (maybeDriver.isPresent() && maybeDriver.get().getHeat().getId() == heat.getId() && !ghostedPlayers.contains(p.getUniqueId())) {
+                    if (p.isInsideVehicle() && (p.getVehicle() instanceof Boat || p.getVehicle() instanceof ChestBoat)) {
+                        player.showEntity(plugin, p.getVehicle());
+                    }
+
                     player.showEntity(plugin, p);
                     continue;
                 }
@@ -270,6 +274,7 @@ public class LonelinessController implements Listener {
         }
 
         Player player = event.getPlayer();
+        updatePlayersVisibility(player);
         updatePlayerVisibility(player);
     }
 

--- a/src/main/java/me/makkuusen/timing/system/tplayer/Settings.java
+++ b/src/main/java/me/makkuusen/timing/system/tplayer/Settings.java
@@ -4,13 +4,9 @@ import co.aikar.idb.DbRow;
 import lombok.Getter;
 import me.makkuusen.timing.system.TimingSystem;
 import me.makkuusen.timing.system.database.EventDatabase;
-import me.makkuusen.timing.system.loneliness.LonelinessController;
 import net.kyori.adventure.text.format.TextColor;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Boat;
-import org.bukkit.entity.ChestBoat;
-
 import java.awt.*;
 import java.util.UUID;
 
@@ -41,7 +37,6 @@ public class Settings {
         compactScoreboard = getBoolean(data, "compactScoreboard");
         sendFinalLaps = getBoolean(data, "sendFinalLaps");
         shortName = data.getString("shortName") != null ? data.getString("shortName") : extractShortName(tPlayer.getName());
-        lonely = getBoolean(data, "lonely");
     }
 
     private String extractShortName(String name) {
@@ -103,29 +98,6 @@ public class Settings {
     public void toggleVerbose() {
         verbose = !verbose;
         TimingSystem.getDatabase().playerUpdateValue(uuid, "verbose", verbose);
-    }
-
-    public void toggleLonely() {
-        lonely = !lonely;
-        TimingSystem.getDatabase().playerUpdateValue(uuid, "lonely", lonely);
-
-
-        if (Bukkit.getPlayer(uuid).isInsideVehicle() && (Bukkit.getPlayer(uuid).getVehicle() instanceof Boat || Bukkit.getPlayer(uuid).getVehicle() instanceof ChestBoat)) {
-            LonelinessController.updateBoatsVisibility(Bukkit.getPlayer(uuid), lonely);
-        }
-    }
-
-    public void setLonely(boolean lonely) {
-        this.lonely = lonely;
-        TimingSystem.getDatabase().playerUpdateValue(uuid, "lonely", lonely);
-
-        if (Bukkit.getPlayer(uuid).isInsideVehicle() && (Bukkit.getPlayer(uuid).getVehicle() instanceof Boat || Bukkit.getPlayer(uuid).getVehicle() instanceof ChestBoat)) {
-            LonelinessController.updateBoatsVisibility(Bukkit.getPlayer(uuid), lonely);
-        }
-    }
-
-    public boolean isLonely() {
-        return lonely;
     }
 
     public void toggleTimeTrial() {


### PR DESCRIPTION
Loneliness is now out of the hands of the players, loneliness will apply automatically on starting a time trial, this means players should never be obstructed during a time trial, and are also unable to perform illegal times via boat taps.

A loneliness system is applied to heats so that all players and boats not in the heat will be hidden to those players in the heat.

Heats with loneliness will spawn all players on the same grid spot or qualy grid spot, in the future I would like to add an option for which format to use, and also stack extra players on the final grid if there are not enough grids available.