### PR TITLE
Spam due to broken condition

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/TSListener.java
+++ b/src/main/java/me/makkuusen/timing/system/TSListener.java
@@ -368,10 +368,10 @@ public class TSListener implements Listener {
 
         if (!TimeTrialController.timeTrials.containsKey(e.getPlayer().getUniqueId())) {
             Player player = e.getPlayer();
-            if (player.getInventory().getChestplate() == null || !player.getInventory().getChestplate().getItemMeta().hasCustomModelData()) {
+            var elytra = player.getInventory().getChestplate();
+            if (elytra == null || elytra.getItemMeta() == null || !elytra.getItemMeta().hasCustomModelData()) {
                 return;
             }
-            var elytra = player.getInventory().getChestplate();
             if (!player.isGliding() && elytra.getItemMeta().getCustomModelData() == 747) {
                 if (TimeTrialController.elytraProtection.get(player.getUniqueId()) != null) {
                     if (TimingSystem.currentTime.getEpochSecond() > TimeTrialController.elytraProtection.get(player.getUniqueId())) {


### PR DESCRIPTION
A broken condition check causes the below spam.

```
[17:28:19 ERROR]: Could not pass event PlayerMoveEvent to TimingSystem v3.0-SNAPSHOT+2025+july.16
java.lang.NullPointerException: Cannot invoke "org.bukkit.inventory.meta.ItemMeta.hasCustomModelData()" because the return value of "org.bukkit.inventory.ItemStack.getItemMeta()" is null
        at TimingSystem-3.0-SNAPSHOT+2025+july.16.jar/me.makkuusen.timing.system.TSListener.onPlayerMoveEventRemoveElytra(TSListener.java:371) ~[TimingSystem-3.0-SNAPSHOT+2025+july.16.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.21.7-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:71) ~[paper-api-1.21.7-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.21.7-R0.1-SNAPSHOT.jar:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleMovePlayer(ServerGamePacketListenerImpl.java:1649) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.network.protocol.game.ServerboundMovePlayerPacket.handle(ServerboundMovePlayerPacket.java:62) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.network.protocol.game.ServerboundMovePlayerPacket$Pos.handle(ServerboundMovePlayerPacket.java:101) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:29) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:155) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1449) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:176) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:129) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1429) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1423) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:139) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.server.MinecraftServer.managedBlock(MinecraftServer.java:1380) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1388) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1265) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310) ~[paper-1.21.7.jar:1.21.7-32-e792779]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```