### PR TITLE
[GH-82] Add command specific permission for /t alltimes <player>

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/commands/CommandTrack.java
+++ b/src/main/java/me/makkuusen/timing/system/commands/CommandTrack.java
@@ -393,7 +393,7 @@ public class CommandTrack extends BaseCommand {
         TPlayer tPlayer;
         if (name != null) {
 
-            if (!player.hasPermission("timingsystem.packs.trackadmin")) {
+            if (!player.hasPermission("timingsystem.packs.trackadmin") && !player.hasPermission(PermissionTrack.VIEW_ALLTIMES.getNode())) {
                 Text.send(player, Error.PERMISSION_DENIED);
                 return;
             }


### PR DESCRIPTION
Fixes: GH-82

With this utility in place, the new behavior checks things in this order:

1. `player.hasPermission("timingsystem.packs.trackadmin")`
2. `player.hasPermission(PermissionTrack.VIEW_ALLTIMES.getNode())` -- that’s basically `timingsystem.tracks.view.alltimes`

If neither of those checks pass, the ERS kicks in.