### PR TITLE
feat: add ghost symbol to scoreboard when player is ghosted

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/heat/DriverScoreboard.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/DriverScoreboard.java
@@ -102,7 +102,9 @@ public class DriverScoreboard {
         if (heat.getRound() instanceof QualificationRound) {
             lines.add(getDriverRowQualification(driver, this.driver, tPlayer.getSettings().getCompactScoreboard(), tPlayer.getTheme()));
         } else if (isGhosted(driver.getTPlayer().getUniqueId())) {
-            lines.add(getDriverRowFinal(driver, this.driver, tPlayer.getSettings().getCompactScoreboard(), tPlayer.getTheme()).color(TextColor.color(0xAAAAAA)));
+            Component row = getDriverRowFinal(driver, this.driver, tPlayer.getSettings().getCompactScoreboard(), tPlayer.getTheme());
+            row = Component.text("👻 ").append(row);
+            lines.add(row.color(TextColor.color(0xAAAAAA)));
         } else {
             lines.add(getDriverRowFinal(driver, this.driver, tPlayer.getSettings().getCompactScoreboard(), tPlayer.getTheme()));
         }

--- a/src/main/java/me/makkuusen/timing/system/heat/SpectatorScoreboard.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/SpectatorScoreboard.java
@@ -89,7 +89,9 @@ public class SpectatorScoreboard {
                     compareToFirst = false;
                 }
             } else if (isGhosted(driver.getTPlayer().getUniqueId())) {
-                lines.add(getDriverRowFinal(driver, prevDriver, tPlayer.getSettings().getCompactScoreboard(), tPlayer.getTheme()).color(TextColor.color(0xAAAAAA)));
+                Component row = getDriverRowFinal(driver, prevDriver, tPlayer.getSettings().getCompactScoreboard(), tPlayer.getTheme());
+                row = Component.text("👻 ").append(row);
+                lines.add(row.color(TextColor.color(0xAAAAAA)));
                 prevDriver = driver;
             } else {
                 lines.add(getDriverRowFinal(driver, prevDriver, tPlayer.getSettings().getCompactScoreboard(), tPlayer.getTheme()));


### PR DESCRIPTION
This PR adds a ghost symbol (👻) to the scoreboard when a player is ghosted. 
The row is also tinted gray as before.

Closes #80 
