### PR TITLE
Closes #156

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.makkuusen.timing.system</groupId>
     <artifactId>TimingSystem</artifactId>
-    <version>3.3.1</version>
+    <version>3.3.2-SNAPSHOT+2026.march.15</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/me/makkuusen/timing/system/commands/CommandEvent.java
+++ b/src/main/java/me/makkuusen/timing/system/commands/CommandEvent.java
@@ -328,6 +328,13 @@ public class CommandEvent extends BaseCommand {
                 event.removeSubscriber(tPlayer.getUniqueId());
                 Text.send(player, Warning.PLAYER_NO_LONGER_SIGNED, "%player%", tPlayer.getName(), "%event%", event.getDisplayName());
             } else {
+                if (!event.isOpenSign()) {
+                    if (!player.hasPermission("timingsystem.packs.eventadmin")) {
+                        Text.send(player, Error.NOT_NOW);
+                        return;
+                    }
+                }
+
                 if (event.isReserving(tPlayer.getUniqueId())) {
                     event.removeReserve(tPlayer.getUniqueId());
                 }
@@ -349,7 +356,7 @@ public class CommandEvent extends BaseCommand {
             Text.send(player, Warning.NO_LONGER_SIGNED, "%event%", event.getDisplayName());
         } else {
             if (!event.isOpenSign()) {
-                if (!(player.hasPermission(PermissionEvent.SIGN.getNode()) || player.hasPermission("timingsystem.packs.eventadmin"))) {
+                if (!player.hasPermission("timingsystem.packs.eventadmin")) {
                     Text.send(player, Error.NOT_NOW);
                     return;
                 }


### PR DESCRIPTION
Before:
/event sign <event> <name> doesn't check if signs are open.

/event sign <event> does.
Players with PermissionEvent.SIGN.getNode() (timingsystem.event.sign) or timingsystem.packs.eventadmin bypass this protection.

After:
/event sign <event> <name> and /event sign <event> both check if signs are open. Players with timingsystem.packs.eventadmin bypass this protection.

Players or others can still remove players with signs closed if event is in SETUP.