### PR TITLE
Fixed chest boats not spawning correctly

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/boat/DefaultBoatSpawner.java
+++ b/src/main/java/me/makkuusen/timing/system/boat/DefaultBoatSpawner.java
@@ -15,49 +15,49 @@ public class DefaultBoatSpawner implements BoatSpawner {
 		switch (woodType) {
 			case "ACACIA" -> {
 				if (chestBoat) {
-					boat = (AcaciaBoat) location.getWorld().spawnEntity(location, EntityType.ACACIA_CHEST_BOAT);
+					boat = (AcaciaChestBoat) location.getWorld().spawnEntity(location, EntityType.ACACIA_CHEST_BOAT);
 				} else {
 					boat = (AcaciaBoat) location.getWorld().spawnEntity(location, EntityType.ACACIA_BOAT);
 				}
 			}
 			case "BIRCH" -> {
 				if (chestBoat) {
-					boat = (BirchBoat) location.getWorld().spawnEntity(location, EntityType.BIRCH_CHEST_BOAT);
+					boat = (BirchChestBoat) location.getWorld().spawnEntity(location, EntityType.BIRCH_CHEST_BOAT);
 				} else {
 					boat = (BirchBoat) location.getWorld().spawnEntity(location, EntityType.BIRCH_BOAT);
 				}
 			}
 			case "DARK_OAK" -> {
 				if (chestBoat) {
-					boat = (DarkOakBoat) location.getWorld().spawnEntity(location, EntityType.DARK_OAK_CHEST_BOAT);
+					boat = (DarkOakChestBoat) location.getWorld().spawnEntity(location, EntityType.DARK_OAK_CHEST_BOAT);
 				} else {
 					boat = (DarkOakBoat) location.getWorld().spawnEntity(location, EntityType.DARK_OAK_BOAT);
 				}
 			}
 			case "SPRUCE" -> {
 				if (chestBoat) {
-					boat = (SpruceBoat) location.getWorld().spawnEntity(location, EntityType.SPRUCE_CHEST_BOAT);
+					boat = (SpruceChestBoat) location.getWorld().spawnEntity(location, EntityType.SPRUCE_CHEST_BOAT);
 				} else {
 					boat = (SpruceBoat) location.getWorld().spawnEntity(location, EntityType.SPRUCE_BOAT);
 				}
 			}
 			case "JUNGLE" -> {
 				if (chestBoat) {
-					boat = (JungleBoat) location.getWorld().spawnEntity(location, EntityType.JUNGLE_CHEST_BOAT);
+					boat = (JungleChestBoat) location.getWorld().spawnEntity(location, EntityType.JUNGLE_CHEST_BOAT);
 				} else {
 					boat = (JungleBoat) location.getWorld().spawnEntity(location, EntityType.JUNGLE_BOAT);
 				}
 			}
 			case "MANGROVE" -> {
 				if (chestBoat) {
-					boat = (MangroveBoat) location.getWorld().spawnEntity(location, EntityType.MANGROVE_CHEST_BOAT);
+					boat = (MangroveChestBoat) location.getWorld().spawnEntity(location, EntityType.MANGROVE_CHEST_BOAT);
 				} else {
 					boat = (MangroveBoat) location.getWorld().spawnEntity(location, EntityType.MANGROVE_BOAT);
 				}
 			}
 			case "CHERRY" -> {
 				if (chestBoat) {
-					boat = (CherryBoat) location.getWorld().spawnEntity(location, EntityType.CHERRY_CHEST_BOAT);
+					boat = (CherryChestBoat) location.getWorld().spawnEntity(location, EntityType.CHERRY_CHEST_BOAT);
 				} else {
 					boat = (CherryBoat) location.getWorld().spawnEntity(location, EntityType.CHERRY_BOAT);
 				}
@@ -71,7 +71,7 @@ public class DefaultBoatSpawner implements BoatSpawner {
 			}
 			default -> {
 				if (chestBoat) {
-					boat = (OakBoat) location.getWorld().spawnEntity(location, EntityType.OAK_CHEST_BOAT);
+					boat = (OakChestBoat) location.getWorld().spawnEntity(location, EntityType.OAK_CHEST_BOAT);
 				} else {
 					boat = (OakBoat) location.getWorld().spawnEntity(location, EntityType.OAK_BOAT);
 				}


### PR DESCRIPTION
Fixed Issue 172 [https://github.com/FrostHexABG/TimingSystem/issues/172](url)

Previously when selecting a chest boat with /settings and typing /b, the boat would spawn but the player would not be inside and it would sit there on the ground without deleting

Now chest boats work as any other boats do

Note: Bamboo Chest Rafts already worked as intended before this change (idk we didn't catch this bug when bamboo rafts were added)

I did test, seems to have fixed it perfectly

Edit: I never tested if chest boats currently work on FrostHex. If chest boats do work it might be something to do with Bukkit version differences. Eitherway I was able to recreate and fix the bug on my own testing server. I just got no clue if FrostHex needs this or not.