### PR TITLE
block broken builds of OpenBoatUtils

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/boatutils/BoatUtilsManager.java
+++ b/src/main/java/me/makkuusen/timing/system/boatutils/BoatUtilsManager.java
@@ -11,6 +11,7 @@ import me.makkuusen.timing.system.theme.messages.Hover;
 import me.makkuusen.timing.system.theme.messages.Warning;
 import me.makkuusen.timing.system.track.Track;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import org.bukkit.Bukkit;
@@ -34,6 +35,17 @@ public class BoatUtilsManager {
         short packetID = in.readShort();
         if (packetID == 0) {
             int version = in.readInt();
+
+            boolean is_broken = switch (version) {
+                case 20, 12, 8 -> true;
+                default -> false;
+            };
+
+            if (is_broken) {
+                player.kick(Component.text("Broken version of OpenBoatUtils. Please update https://modrinth.com/mod/openboatutils", NamedTextColor.RED));
+                return;
+            }
+
             TPlayer tPlayer = TSDatabase.getPlayer(player.getUniqueId());
             tPlayer.setBoatUtilsVersion(version);
 

--- a/src/main/java/me/makkuusen/timing/system/boatutils/CustomBoatUtilsMode.java
+++ b/src/main/java/me/makkuusen/timing/system/boatutils/CustomBoatUtilsMode.java
@@ -611,7 +611,7 @@ public class CustomBoatUtilsMode {
                  "multiStepping",
                  "maxSpeed",
                  "maxSpeedResistance",
-                 "honeyCompatibility" -> 20;
+                 "honeyCompatibility" -> 21;
             default -> 11;
         };
     }


### PR DESCRIPTION
Adds a check that blocks known bad versions of OpenBoatUtils.
- mostly mirrors https://openboatutils.github.io/developers/versions.html
- this could be upgraded using the configuration phase packet but I don't want add a dependency on packet events / protocollib
