### PR TITLE
Add config option to disable loneliness

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/TimingSystemConfiguration.java
+++ b/src/main/java/me/makkuusen/timing/system/TimingSystemConfiguration.java
@@ -36,6 +36,7 @@ public class TimingSystemConfiguration {
     private Double pushToPassForwardAccel;
     private Integer pushToPassStartingCharge;
     private Boolean pushToPassParticlesToggle;
+    private final boolean lonelinessEnabled;
     private final boolean frostHexAddOnEnabled;
     private final boolean medalsAddOnEnabled;
     private final boolean medalsShowNextMedal;
@@ -84,6 +85,7 @@ public class TimingSystemConfiguration {
         pushToPassForwardAccel = plugin.getConfig().getDouble("pushtopass.forwardAccel", 0.05);
         pushToPassStartingCharge = plugin.getConfig().getInt("pushtopass.startingCharge", 0);
         pushToPassParticlesToggle = plugin.getConfig().getBoolean("pushtopass.particlestoggle", true);
+        lonelinessEnabled = plugin.getConfig().getBoolean("loneliness.enabled", true);
         frostHexAddOnEnabled = plugin.getConfig().getBoolean("frosthexaddon.enabled");
         medalsAddOnEnabled = plugin.getConfig().getBoolean("medalsaddon.enabled");
         medalsShowNextMedal = plugin.getConfig().getBoolean("medalsaddon.showNextMedal");

--- a/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
+++ b/src/main/java/me/makkuusen/timing/system/loneliness/LonelinessController.java
@@ -55,6 +55,9 @@ public class LonelinessController implements Listener {
                     // Show all drivers, activate nocol
                     showAllOthers(player);
                     setCollisionMode(player, false);
+                } else if (!TimingSystem.configuration.isLonelinessEnabled()) {
+                    // Loneliness disabled by config outside of loneliness heats
+                    showAllOthers(player);
                 } else {
                     // Hide all players
                     hideAllOthers(player);
@@ -232,28 +235,24 @@ public class LonelinessController implements Listener {
         boolean canUseNocol = playerCanUseNocol(viewingPlayer);
         boolean lonelinessDisabled = !TimingSystemAPI.getTPlayer(viewingPlayer.getUniqueId()).getSettings().isLonely();
 
-        if (canUseNocol && lonelinessDisabled) {
+        Optional<Driver> viewingMaybeDriver = getDriverFromRunningHeat(viewingPlayer);
+        Heat viewingStreakingHeat = getStreakingHeat(viewingPlayer);
+        boolean viewingIsDriver = viewingMaybeDriver.isPresent();
+        Heat viewingHeat = viewingIsDriver ? viewingMaybeDriver.get().getHeat() : viewingStreakingHeat;
+
+        // When loneliness is disabled by config, it only applies in loneliness heats (collision mode DISABLED)
+        boolean lonelinessApplies = TimingSystem.configuration.isLonelinessEnabled()
+                || (viewingHeat != null && viewingHeat.getCollisionMode() == CollisionMode.DISABLED);
+
+        if ((canUseNocol && lonelinessDisabled) || !lonelinessApplies) {
             showPlayerAndCustomBoat(viewingPlayer, targetPlayer);
         } else {
             hidePlayerAndCustomBoat(viewingPlayer, targetPlayer);
         }
 
-        Optional<Driver> viewingMaybeDriver = getDriverFromRunningHeat(viewingPlayer);
-        Heat viewingStreakingHeat = getStreakingHeat(viewingPlayer);
-        
-        if (!viewingMaybeDriver.isPresent() && viewingStreakingHeat == null) return;
+        if (viewingHeat == null) return;
 
-        Heat viewingHeat;
-        boolean viewingIsDriver = viewingMaybeDriver.isPresent();
-        
-        if (viewingIsDriver) {
-            Driver viewingDriver = viewingMaybeDriver.get();
-            viewingHeat = viewingDriver.getHeat();
-            if (isDriverNotParticipating(viewingDriver)) return;
-        } else {
-            // Viewing player is a streaker
-            viewingHeat = viewingStreakingHeat;
-        }
+        if (viewingIsDriver && isDriverNotParticipating(viewingMaybeDriver.get())) return;
 
         Optional<Driver> targetMaybeDriver = getDriverFromRunningHeat(targetPlayer);
         boolean targetIsStreaker = viewingHeat.getStreakers().containsKey(targetPlayer.getUniqueId());

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,5 @@
+loneliness:
+   enabled: true
 frosthexaddon:
    enabled: false
 medalsaddon:


### PR DESCRIPTION
Adds an option to the config to disable loneliness functionality outside of racing heats, solves #158 